### PR TITLE
nindmatch_leq_nminmatch の証明の一部を１行に戻しました。

### DIFF
--- a/graph.v
+++ b/graph.v
@@ -1091,9 +1091,7 @@ rewrite 2!cardfE.
 set f : N -> M := fun n => [` (psi_M Mmax (val n)) ].
 apply: (leq_card f).
 move=> e0 e1.
-move/eqP => fe01.
-apply/eqP.
-move: fe01.
+move/eqP => fe01; apply/eqP; move: fe01.
 move/(psi_inj Nind).
 rewrite /f.
 by rewrite 2!fsvalP => /(_ erefl erefl).


### PR DESCRIPTION
nindmatch_leq_nminmatch の証明の中で、おそらくもともとは１行であった部分が、３行ほどに分割されていたので、１行に戻しました。
Goal の "=" を "==" に変えるという意図で書かれた部分なので、１行の方がよいと判断しました。